### PR TITLE
Fix force unwrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Add a dependency on qualtrics-digital-ios-sdk to your iOS application through Xc
 
 #### 5. Verify that the package has been added to your Project Navigator in Xcode, under `Package Dependencies` (In this example, it is directly under our example app `QualtricsSDKSwiftUI`):
 ![step 5](https://github.com/qualtrics/qualtrics-digital-ios-sdk/blob/main/ReadMeFiles/step5.png?raw=true)
+
+update


### PR DESCRIPTION
Hi,
Since the `Issues` tab is not enabled, the only way I found to submit an issue was to open a PR. We've using the SDK v2.11.0 and noticed there are some force unwrap happening within the SDK and causes our app to crash. Can we get a fix in for them ASAP? I've attached some crash report which indicates where force unwrap happening.

@rbalog-qualtrics @zofiaw-qualtrics 

<img width="653" alt="Screenshot 2023-05-31 at 10 09 04 AM" src="https://github.com/qualtrics/qualtrics-digital-ios-sdk/assets/8564158/ab53896c-d59b-4ecf-a2dc-9f2d326293a6">
<img width="650" alt="Screenshot 2023-05-31 at 10 08 53 AM" src="https://github.com/qualtrics/qualtrics-digital-ios-sdk/assets/8564158/196e43a3-2d29-44b5-a3cc-460e94254982">
<img width="651" alt="Screenshot 2023-05-31 at 10 08 48 AM" src="https://github.com/qualtrics/qualtrics-digital-ios-sdk/assets/8564158/f0ebb47f-8fed-4d4b-bd33-7a313f87ad68">
<img width="650" alt="Screenshot 2023-05-31 at 10 07 58 AM" src="https://github.com/qualtrics/qualtrics-digital-ios-sdk/assets/8564158/eca549d1-a1e2-452b-a82f-37d1018514bf">
<img width="640" alt="Screenshot 2023-05-31 at 10 08 05 AM" src="https://github.com/qualtrics/qualtrics-digital-ios-sdk/assets/8564158/84add65b-d3be-4e09-88db-7ef8c28b6ca9">
